### PR TITLE
Return a 400 if no data was sent in a PATCH request

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -1396,6 +1396,9 @@ class Resource(object):
         request = convert_post_to_patch(request)
         deserialized = self.deserialize(request, request.body, format=request.META.get('CONTENT_TYPE', 'application/json'))
 
+        if deserialized is None:
+            raise BadRequest("No data sent")
+
         collection_name = self._meta.collection_name
         deleted_collection_name = 'deleted_%s' % collection_name
         if collection_name not in deserialized:


### PR DESCRIPTION
This is to fix errors such as [this](https://app.datadoghq.com/logs?cols=core_host%2Ccore_service&context_event=AQAAAWtmsdH-34ZoZAAAAABBV3Rtc2RJa1c1VHVDdXh1T1gzWg&event=AQAAAWtmsdH-34ZoZAAAAABBV3Rtc2RJa1c1VHVDdXh1T1gzWg&from_ts=1560622623464&index=main&live=false&messageDisplay=inline&query=host%3AProdFrontend311-10-0-1-229+service%3Adjserver_json+filename%3Ajsonlogs.log&saved_view&stream_sort=desc&to_ts=1560796058110) where we are returning a 500 error because the user did not send any data in a PATCH request